### PR TITLE
notify the error message instead of crashing all page when save dashboard failed

### DIFF
--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -268,7 +268,7 @@ app.directive('dashboardApp', function ($injector) {
             }
           }
           return id;
-        }).catch(notify.fatal);
+        }).catch(notify.error);
       };
 
       const navActions = {};


### PR DESCRIPTION
notify the error message instead of crashing all page when save dashboard failed